### PR TITLE
Add custom toolchain rule

### DIFF
--- a/xcodeproj/defs.bzl
+++ b/xcodeproj/defs.bzl
@@ -24,6 +24,7 @@ load(
 )
 load("//xcodeproj/internal:xcodeprojinfo.bzl", _XcodeProjInfo = "XcodeProjInfo")
 load("//xcodeproj/internal/xcschemes:xcschemes.bzl", _xcschemes = "xcschemes")
+load("//xcodeproj/internal:custom_toolchain.bzl", _custom_toolchain = "custom_toolchain")
 
 # Re-exporting providers
 XcodeProjAutomaticTargetProcessingInfo = _XcodeProjAutomaticTargetProcessingInfo
@@ -35,6 +36,7 @@ top_level_target = _top_level_target
 top_level_targets = _top_level_targets
 xcodeproj = _xcodeproj
 xcode_provisioning_profile = _xcode_provisioning_profile
+custom_toolchain = _custom_toolchain
 
 # Re-exporting APIs
 xcode_schemes = _xcode_schemes

--- a/xcodeproj/internal/custom_toolchain.bzl
+++ b/xcodeproj/internal/custom_toolchain.bzl
@@ -1,0 +1,90 @@
+def _custom_toolchain_impl(ctx):
+    toolchain_dir = ctx.actions.declare_directory(ctx.attr.toolchain_name + ".xctoolchain")
+    toolchain_info_plist_file = ctx.actions.declare_file(ctx.attr.toolchain_name + "_ToolchainInfo.plist")
+    info_plist_file = ctx.actions.declare_file(ctx.attr.toolchain_name + "_Info.plist")
+
+    default_toolchain_path = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain"
+
+    # Generate symlink creation commands dynamically, excluding ToolchainInfo.plist
+    symlink_script = """#!/bin/bash
+set -e
+
+mkdir -p "{toolchain_dir}"
+
+find "{default_toolchain}" -type f -o -type l | while read file; do
+    rel_path="${{file#"{default_toolchain}/"}}"
+    if [[ "$rel_path" != "ToolchainInfo.plist" && "$rel_path" != "Info.plist" ]]; then
+        mkdir -p "{toolchain_dir}/$(dirname "$rel_path")"
+        ln -s "$file" "{toolchain_dir}/$rel_path"
+    fi
+done
+
+mkdir -p "{toolchain_dir}"
+mv "{toolchain_info_plist}" "{toolchain_dir}/ToolchainInfo.plist"
+mv "{info_plist}" "{toolchain_dir}/Info.plist"
+""".format(
+        toolchain_dir=toolchain_dir.path,
+        default_toolchain=default_toolchain_path,
+        toolchain_info_plist=toolchain_info_plist_file.path,
+        info_plist=info_plist_file.path
+    )
+
+    script_file = ctx.actions.declare_file(ctx.attr.toolchain_name + "_setup.sh")
+    ctx.actions.write(output=script_file, content=symlink_script, is_executable=True)
+
+    # Generate ToolchainInfo.plist separately
+    toolchain_info_plist_content = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Identifier</key>
+    <string>com.example.{name}</string>
+    <key>DisplayName</key>
+    <string>{name}</string>
+    <key>CompatibilityVersion</key>
+    <string>9999</string>
+</dict>
+</plist>
+""".format(name=ctx.attr.toolchain_name)
+
+    ctx.actions.write(output=toolchain_info_plist_file, content=toolchain_info_plist_content)
+
+    # Generate Info.plist
+    info_plist_content = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.{name}</string>
+    <key>CFBundleName</key>
+    <string>{name}</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>DTSDKName</key>
+    <string>macosx</string>
+    <key>DTSDKBuild</key>
+    <string>9999</string>
+    <key>DTCompiler</key>
+    <string>com.apple.compilers.llvm.clang.1_0</string>
+</dict>
+</plist>
+""".format(name=ctx.attr.toolchain_name)
+
+    ctx.actions.write(output=info_plist_file, content=info_plist_content)
+
+    # Run the generated shell script
+    ctx.actions.run_shell(
+        outputs=[toolchain_dir],
+        inputs=[toolchain_info_plist_file, info_plist_file],
+        tools=[script_file],
+        command=script_file.path
+    )
+
+    return [DefaultInfo(files=depset([toolchain_dir]))]
+
+custom_toolchain = rule(
+    implementation=_custom_toolchain_impl,
+    attrs={
+        "toolchain_name": attr.string(mandatory=True),
+    },
+)

--- a/xcodeproj/internal/custom_toolchain.bzl
+++ b/xcodeproj/internal/custom_toolchain.bzl
@@ -1,11 +1,11 @@
 def _custom_toolchain_impl(ctx):
     toolchain_dir = ctx.actions.declare_directory(ctx.attr.toolchain_name + ".xctoolchain")
-    toolchain_info_plist_file = ctx.actions.declare_file(ctx.attr.toolchain_name + "_ToolchainInfo.plist")
-    info_plist_file = ctx.actions.declare_file(ctx.attr.toolchain_name + "_Info.plist")
+    toolchain_plist_file = ctx.actions.declare_file(ctx.attr.toolchain_name + "_ToolchainInfo.plist")
 
     default_toolchain_path = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain"
+    user_toolchain_path = "$(eval echo ~)/Library/Developer/Toolchains/{}.xctoolchain".format(ctx.attr.toolchain_name)
 
-    # Generate symlink creation commands dynamically, excluding ToolchainInfo.plist
+    # Generate symlink creation commands dynamically, excluding plist files
     symlink_script = """#!/bin/bash
 set -e
 
@@ -13,69 +13,63 @@ mkdir -p "{toolchain_dir}"
 
 find "{default_toolchain}" -type f -o -type l | while read file; do
     rel_path="${{file#"{default_toolchain}/"}}"
-    if [[ "$rel_path" != "ToolchainInfo.plist" && "$rel_path" != "Info.plist" ]]; then
+    if [[ "$rel_path" != "ToolchainInfo.plist" ]]; then
         mkdir -p "{toolchain_dir}/$(dirname "$rel_path")"
         ln -s "$file" "{toolchain_dir}/$rel_path"
     fi
 done
 
 mkdir -p "{toolchain_dir}"
-mv "{toolchain_info_plist}" "{toolchain_dir}/ToolchainInfo.plist"
-mv "{info_plist}" "{toolchain_dir}/Info.plist"
+mv "{toolchain_plist}" "{toolchain_dir}/ToolchainInfo.plist"
+
+# Remove existing symlink if present and create a new one in the user directory
+if [ -e "{user_toolchain_path}" ]; then
+    rm -f "{user_toolchain_path}"
+fi
+ln -s "{toolchain_dir}" "{user_toolchain_path}"
 """.format(
         toolchain_dir=toolchain_dir.path,
         default_toolchain=default_toolchain_path,
-        toolchain_info_plist=toolchain_info_plist_file.path,
-        info_plist=info_plist_file.path
+        toolchain_plist=toolchain_plist_file.path,
+        user_toolchain_path=user_toolchain_path
     )
 
     script_file = ctx.actions.declare_file(ctx.attr.toolchain_name + "_setup.sh")
     ctx.actions.write(output=script_file, content=symlink_script, is_executable=True)
 
-    # Generate ToolchainInfo.plist separately
-    toolchain_info_plist_content = """<?xml version="1.0" encoding="UTF-8"?>
+    # Generate ToolchainInfo.plist
+    toolchain_plist_content = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-    <key>Identifier</key>
-    <string>com.example.{name}</string>
-    <key>DisplayName</key>
-    <string>{name}</string>
-    <key>CompatibilityVersion</key>
-    <string>9999</string>
-</dict>
-</plist>
-""".format(name=ctx.attr.toolchain_name)
-
-    ctx.actions.write(output=toolchain_info_plist_file, content=toolchain_info_plist_content)
-
-    # Generate Info.plist
-    info_plist_content = """<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
+  <dict>
+    <key>Aliases</key>
+    <array>
+      <string>{name}</string>
+    </array>
     <key>CFBundleIdentifier</key>
     <string>com.example.{name}</string>
-    <key>CFBundleName</key>
+    <key>CompatibilityVersion</key>
+    <integer>2</integer>
+    <key>CompatibilityVersionDisplayString</key>
+    <string>Xcode 13.0</string>
+    <key>DisplayName</key>
     <string>{name}</string>
-    <key>CFBundleVersion</key>
-    <string>1.0</string>
-    <key>DTSDKName</key>
-    <string>macosx</string>
-    <key>DTSDKBuild</key>
-    <string>9999</string>
-    <key>DTCompiler</key>
-    <string>com.apple.compilers.llvm.clang.1_0</string>
-</dict>
+    <key>ReportProblemURL</key>
+    <string>https://github.com/MobileNativeFoundation/rules_xcodeproj</string>
+    <key>ShortDisplayName</key>
+    <string>{name}</string>
+    <key>Version</key>
+    <string>0.0.1</string>
+  </dict>
 </plist>
 """.format(name=ctx.attr.toolchain_name)
 
-    ctx.actions.write(output=info_plist_file, content=info_plist_content)
+    ctx.actions.write(output=toolchain_plist_file, content=toolchain_plist_content)
 
     # Run the generated shell script
     ctx.actions.run_shell(
         outputs=[toolchain_dir],
-        inputs=[toolchain_info_plist_file, info_plist_file],
+        inputs=[toolchain_plist_file],
         tools=[script_file],
         command=script_file.path
     )

--- a/xcodeproj/internal/custom_toolchain.bzl
+++ b/xcodeproj/internal/custom_toolchain.bzl
@@ -4,7 +4,7 @@ def _custom_toolchain_impl(ctx):
 
     default_toolchain_path = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain"
     user_toolchain_path = "$(eval echo ~)/Library/Developer/Toolchains/{}.xctoolchain".format(ctx.attr.toolchain_name)
-    built_toolchain_path = toolchain_dir.path
+    built_toolchain_path = "$(eval pwd)/"+toolchain_dir.path
 
     # Generate symlink creation commands dynamically, excluding plist files
     symlink_script = """#!/bin/bash


### PR DESCRIPTION
This rule creates a new custom toolchain with symlinks back to all the tools in the default toolchain. To execute include the rule and add the following to your BUILD:

```
custom_toolchain(
    name = "CustomToolchain",
    toolchain_name = "MyCustomToolchain"
)
```

`bazel build //:CustomToolchain`

now produces `MyCustomToolchain.xctoolchain` in generated `bazel-bin`. This toolchain is then symlinked into `~/Library/Developer/Toolchains` in order to be picked up from xcode.